### PR TITLE
clarify that security policy is for the matrix bridge only

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 **If you've found a security vulnerability with the Libera Chat _Matrix Bridge Service_, please report it to security@matrix.org**
 
-**If you've found a vulnerablility with the Libera Chat _IRC Network_, please contact Libera Chat staff by emailing [support@libera.chat](mailto:support@libera.chat) or by private messsaging an active staffer on IRC**
+**If you've found a vulnerablility with the Libera Chat _IRC Network_, please contact Libera Chat staff by emailing [support@libera.chat](mailto:support@libera.chat) or by private messsaging an [active staffer](https://libera.chat/guides/faq#how-to-find-libera-chat-staff) on IRC**
 
 For more information on our security disclosure policy, visit https://www.matrix.org/security-disclosure-policy/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Reporting a Vulnerability
 
-**If you've found a security vulnerability, please report it to security@matrix.org**
+**If you've found a security vulnerability with the Libera Chat _Matrix Bridge Service_, please report it to security@matrix.org**
+
+**If you've found a vulnerablility with the Libera Chat _IRC Network_, please contact Libera Chat staff by emailing [support@libera.chat](mailto:support@libera.chat) or by private messsaging an active staffer on IRC**
 
 For more information on our security disclosure policy, visit https://www.matrix.org/security-disclosure-policy/


### PR DESCRIPTION
This will help avoid users looking to report a vulnerability with the IRC network from stumbling upon this page and reporting the vulnerability to Matrix staff when it should go to Libera Chat staff.